### PR TITLE
Add preliminary support for private dependencies using builtins.fetchGit

### DIFF
--- a/builder/parse-version.nix
+++ b/builder/parse-version.nix
@@ -1,0 +1,41 @@
+let
+  inherit (builtins) elemAt match hasAttr removeAttrs;
+in
+ver:
+removeAttrs
+  (builtins.foldl' (acc: f: if hasAttr "rest" acc then f acc else acc)
+    {
+      version = "";
+      rev = "";
+      versionSuffix = "";
+      date = "";
+      rest = ver;
+    } [
+    (acc:
+      let
+        m = match "([^-]+)-(.*)" acc.rest;
+        e = elemAt m;
+      in
+      if m != null then {
+        version = e 0;
+        rest = e 1;
+      } else removeAttrs acc [ "rest" ] // {
+        version = ver;
+      })
+    (acc:
+      let
+        m = elemAt (match "(.*)-(.*)" acc.rest);
+      in
+      acc // {
+        rev = m 1;
+        rest = m 0;
+      })
+    (acc:
+      let
+        m = elemAt (match "(.*)\\.(.*)" acc.rest);
+      in
+      acc // {
+        versionSuffix = m 0;
+        date = m 1;
+      })
+  ]) [ "rest" ]

--- a/builder/parser.nix
+++ b/builder/parser.nix
@@ -98,18 +98,6 @@ let
     }
   );
 
-  parseVersion = ver:
-    let
-      m = elemAt (match "([^-]+)-?([^-]*)-?([^-]*)" ver);
-      v = elemAt (match "([^+]+)\\+?(.*)" (m 0));
-    in
-    {
-      version = v 0;
-      versionSuffix = v 1;
-      date = m 1;
-      rev = m 2;
-    };
-
   parseReplace = data: (
     data // {
       replace =

--- a/default.nix
+++ b/default.nix
@@ -8,7 +8,7 @@ buildGoApplication {
   pname = "gomod2nix";
   version = "0.1";
   src = lib.cleanSourceWith {
-    filter = name: type: ! lib.hasSuffix "tests" name;
+    filter = name: type: (! lib.hasSuffix "tests" name) && (! lib.hasSuffix "builder" name);
     src = lib.cleanSource ./.;
   };
   modules = ./gomod2nix.toml;


### PR DESCRIPTION
Add preliminary support for private dependencies using builtins.fetchGit
    
Using this API looks like:
``` nix
buildGoApplication {
  srcOverrides = self: super: {
    "github.com/BurntSushi/toml" = super."github.com/BurntSushi/toml".override { private = true; };
  };
}
```
    
Outstanding issues:
- Nix has issues dealing with short revs ( https://github.com/NixOS/nix/issues/4694 )
- Param passing heuristics to fetchGit needs to be nailed down.