### PR TITLE
Symlink indent dehadouken

### DIFF
--- a/builder/symlink/symlink.go
+++ b/builder/symlink/symlink.go
@@ -3,7 +3,6 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sort"
@@ -21,7 +20,7 @@ func main() {
 	pkgs := make(map[string]*Package)
 
 	{
-		b, err := ioutil.ReadFile(os.Getenv("sourcesPath"))
+		b, err := os.ReadFile(os.Getenv("sourcesPath"))
 		if err != nil {
 			panic(err)
 		}
@@ -33,7 +32,7 @@ func main() {
 	}
 
 	{
-		b, err := ioutil.ReadFile(os.Getenv("jsonPath"))
+		b, err := os.ReadFile(os.Getenv("jsonPath"))
 		if err != nil {
 			panic(err)
 		}
@@ -65,7 +64,7 @@ func main() {
 			}
 
 			if _, err := os.Stat(filepath.Join("vendor", path)); err == nil {
-				files, err := ioutil.ReadDir(src)
+				files, err := os.ReadDir(src)
 				if err != nil {
 					panic(err)
 				}
@@ -76,7 +75,7 @@ func main() {
 					if err := os.Symlink(innerSrc, dst); err != nil {
 						// assume it's an existing directory, try to link the directory content instead.
 						// TODO should we do this recursively
-						files, err := ioutil.ReadDir(innerSrc)
+						files, err := os.ReadDir(innerSrc)
 						if err != nil {
 							panic(err)
 						}

--- a/builder/symlink/symlink.go
+++ b/builder/symlink/symlink.go
@@ -15,33 +15,33 @@ type Package struct {
 	ReplacedPath  string `json:"replaced,omitempty"`
 }
 
+type Sources map[string]string
+
+func populateStruct(path string, data interface{}) {
+	pathVal := os.Getenv(path)
+	if len(path) == 0 {
+		panic(fmt.Sprintf("env var '%s' was unset", path))
+	}
+	path = pathVal
+
+	b, err := os.ReadFile(path)
+	if err != nil {
+		panic(err)
+	}
+
+	err = json.Unmarshal(b, &data)
+	if err != nil {
+		panic(err)
+	}
+}
+
 func main() {
-	sources := make(map[string]string)
+	sources := make(Sources)
 	pkgs := make(map[string]*Package)
 
-	{
-		b, err := os.ReadFile(os.Getenv("sourcesPath"))
-		if err != nil {
-			panic(err)
-		}
+	populateStruct("sourcesPath", &sources)
 
-		err = json.Unmarshal(b, &sources)
-		if err != nil {
-			panic(err)
-		}
-	}
-
-	{
-		b, err := os.ReadFile(os.Getenv("jsonPath"))
-		if err != nil {
-			panic(err)
-		}
-
-		err = json.Unmarshal(b, &pkgs)
-		if err != nil {
-			panic(err)
-		}
-	}
+	populateStruct("jsonPath", &pkgs)
 
 	keys := make([]string, 0, len(pkgs))
 	for key := range pkgs {
@@ -49,6 +49,10 @@ func main() {
 	}
 	sort.Strings(keys)
 
+	makeSymlinks(keys, sources)
+}
+
+func makeSymlinks(keys []string, sources Sources) {
 	// Iterate, in reverse order
 	for i := len(keys) - 1; i >= 0; i-- {
 		key := keys[i]
@@ -57,46 +61,49 @@ func main() {
 		paths := []string{key}
 
 		for _, path := range paths {
-
 			vendorDir := filepath.Join("vendor", filepath.Dir(path))
-			if err := os.MkdirAll(vendorDir, 0755); err != nil {
+			if err := os.MkdirAll(vendorDir, 0o755); err != nil {
 				panic(err)
 			}
 
-			if _, err := os.Stat(filepath.Join("vendor", path)); err == nil {
-				files, err := os.ReadDir(src)
-				if err != nil {
-					panic(err)
-				}
-
-				for _, f := range files {
-					innerSrc := filepath.Join(src, f.Name())
-					dst := filepath.Join("vendor", path, f.Name())
-					if err := os.Symlink(innerSrc, dst); err != nil {
-						// assume it's an existing directory, try to link the directory content instead.
-						// TODO should we do this recursively
-						files, err := os.ReadDir(innerSrc)
-						if err != nil {
-							panic(err)
-						}
-						for _, f := range files {
-							if err := os.Symlink(filepath.Join(innerSrc, f.Name()), filepath.Join(dst, f.Name())); err != nil {
-								fmt.Println("ignore symlink error", filepath.Join(innerSrc, f.Name()), filepath.Join(dst, f.Name()))
-							}
-						}
-					}
-				}
-
+			vendorPath := filepath.Join("vendor", path)
+			if _, err := os.Stat(vendorPath); err == nil {
+				populateVendorPath(vendorPath, src)
 				continue
 			}
 
 			// If the file doesn't already exist, just create a simple symlink
-			err := os.Symlink(src, filepath.Join("vendor", path))
+			err := os.Symlink(src, vendorPath)
 			if err != nil {
 				panic(err)
 			}
-
 		}
 	}
+}
 
+func populateVendorPath(vendorPath string, src string) {
+	files, err := os.ReadDir(src)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, f := range files {
+		innerSrc := filepath.Join(src, f.Name())
+		dst := filepath.Join(vendorPath, f.Name())
+		if err := os.Symlink(innerSrc, dst); err != nil {
+			// assume it's an existing directory, try to link the directory content instead.
+			// TODO should we do this recursively?
+			files, err := os.ReadDir(innerSrc)
+			if err != nil {
+				panic(err)
+			}
+			for _, f := range files {
+				srcFile := filepath.Join(innerSrc, f.Name())
+				dstFile := filepath.Join(dst, f.Name())
+				if err := os.Symlink(srcFile, dstFile); err != nil {
+					fmt.Println("ignoring symlink error", srcFile, dstFile)
+				}
+			}
+		}
+	}
 }

--- a/internal/generate/generate.go
+++ b/internal/generate/generate.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -16,9 +15,9 @@ import (
 	"sync"
 
 	"github.com/nix-community/go-nix/pkg/nar"
-	log "github.com/sirupsen/logrus"
 	"github.com/nix-community/gomod2nix/internal/lib"
 	schema "github.com/nix-community/gomod2nix/internal/schema"
+	log "github.com/sirupsen/logrus"
 	"golang.org/x/mod/modfile"
 )
 
@@ -45,7 +44,7 @@ func common(directory string) ([]*goModDownload, map[string]string, error) {
 	}).Info("Parsing go.mod")
 
 	// Read go.mod
-	data, err := ioutil.ReadFile(goModPath)
+	data, err := os.ReadFile(goModPath)
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
Implement suggestion from https://github.com/NixOS/nixpkgs/pull/188272#discussion_r958608686.

The main difference here is that we use `interface{}` instead of generics as I want this to be compatible with Go <1.18.