### PR TITLE
root expression: Use pwd argument to parse go.mod

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,17 +1,19 @@
 { stdenv
 , callPackage
-, go
 , lib
 , makeWrapper
 , installShellFiles
 , fetchFromGitHub
 , buildGoApplication
 , mkGoEnv
+, which
 }:
 
 buildGoApplication {
   pname = "gomod2nix";
   version = "dev";
+
+  pwd = ./.;
 
   modules = ./gomod2nix.toml;
 
@@ -24,13 +26,11 @@ buildGoApplication {
     src = lib.cleanSource ./.;
   };
 
-  inherit go;
-
   allowGoReference = true;
 
   subPackages = [ "." ];
 
-  nativeBuildInputs = [ makeWrapper installShellFiles ];
+  nativeBuildInputs = [ makeWrapper installShellFiles which ];
 
   passthru = {
     inherit buildGoApplication mkGoEnv;
@@ -42,7 +42,7 @@ buildGoApplication {
       --fish <($out/bin/gomod2nix completion fish) \
       --zsh <($out/bin/gomod2nix completion zsh)
   '' + ''
-    wrapProgram $out/bin/gomod2nix --prefix PATH : ${lib.makeBinPath [ go ]}
+    wrapProgram $out/bin/gomod2nix --prefix PATH : $(dirname $(which go))
   '';
 
   meta = {

--- a/default.nix
+++ b/default.nix
@@ -42,7 +42,7 @@ buildGoApplication {
       --fish <($out/bin/gomod2nix completion fish) \
       --zsh <($out/bin/gomod2nix completion zsh)
   '' + ''
-    wrapProgram $out/bin/gomod2nix --prefix PATH : $(dirname $(which go))
+    wrapProgram $out/bin/gomod2nix --suffix PATH : $(dirname $(which go))
   '';
 
   meta = {

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1658285632,
-        "narHash": "sha256-zRS5S/hoeDGUbO+L95wXG9vJNwsSYcl93XiD0HQBXLk=",
+        "lastModified": 1662100443,
+        "narHash": "sha256-okq9egKcg+BcDvj6RXueAAH65IigrhQ8fcY3+AZIJ/c=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5342fc6fb59d0595d26883c3cadff16ce58e44f3",
+        "rev": "9ed722436a784856b4ee24c0f26cb8c6d6f22240",
         "type": "github"
       },
       "original": {
@@ -24,11 +24,11 @@
     },
     "utils": {
       "locked": {
-        "lastModified": 1653893745,
-        "narHash": "sha256-0jntwV3Z8//YwuOjzhV2sgJJPt+HY6KhU7VZUL0fKZQ=",
+        "lastModified": 1659877975,
+        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "1ed9fb1935d260de5fe1c2f7ee0ebaae17ed2fa1",
+        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
This will ensure that the Go version selector picks the very latest compatible compiler version.

This is a potential alternative fix to https://github.com/nix-community/gomod2nix/issues/91, and I think worthwhile regardless of https://github.com/nix-community/gomod2nix/pull/92.

cc @yihuang 