### PR TITLE
Parameterise `tools.go`

### DIFF
--- a/builder/default.nix
+++ b/builder/default.nix
@@ -161,6 +161,7 @@ let
 
   mkGoEnv =
     { pwd
+    , toolsGo ? pwd + "/tools.go"
     }@attrs:
     let
       goMod = parseGoMod (readFile "${toString pwd}/go.mod");
@@ -201,11 +202,11 @@ let
         export GOSUMDB=off
         export GOPROXY=off
 
-      '' + optionalString (pathExists (pwd + "/tools.go")) ''
+      '' + optionalString (pathExists toolsGo) ''
         mkdir source
         cp ${pwd + "/go.mod"} source/go.mod
         cp ${pwd + "/go.sum"} source/go.sum
-        cp ${pwd + "/tools.go"} source/tools.go
+        cp ${toolsGo} source/tools.go
         cd source
 
         rsync -a -K --ignore-errors ${vendorEnv}/ vendor

--- a/builder/default.nix
+++ b/builder/default.nix
@@ -162,10 +162,11 @@ let
   mkGoEnv =
     { pwd
     , toolsGo ? pwd + "/tools.go"
+    , modules ? pwd + "/gomod2nix.toml"
     }@attrs:
     let
       goMod = parseGoMod (readFile "${toString pwd}/go.mod");
-      modulesStruct = fromTOML (readFile "${toString pwd}/gomod2nix.toml");
+      modulesStruct = fromTOML (readFile modules);
 
       go = selectGo attrs goMod;
 

--- a/docs/nix-reference.md
+++ b/docs/nix-reference.md
@@ -4,7 +4,7 @@
 
 ### buildGoApplication
 Arguments:
-- **modules** Path to gomod2nix.toml (_default: `pwd + "/gomod2nix.toml"`).
+- **modules** Path to `gomod2nix.toml` (_default: `pwd + "/gomod2nix.toml"`).
 - **src** Path to sources (_default: `pwd`).
 - **pwd** Path to working directory (_default: `null`).
 - **go** The Go compiler to use (can be omitted).
@@ -16,6 +16,7 @@ All other arguments are passed verbatim to `stdenv.mkDerivation`.
 ### mkGoEnv
 Arguments:
 - **pwd** Path to working directory.
+- **modules** Path to `gomod2nix.toml` (_default: `pwd + "/gomod2nix.toml"`).
 - **toolsGo** Path to `tools.go` (_default: `pwd + "/tools.go"`).
 
 All other arguments are passed verbatim to `stdenv.mkDerivation`.

--- a/docs/nix-reference.md
+++ b/docs/nix-reference.md
@@ -16,5 +16,6 @@ All other arguments are passed verbatim to `stdenv.mkDerivation`.
 ### mkGoEnv
 Arguments:
 - **pwd** Path to working directory.
+- **toolsGo** Path to `tools.go` (_default: `pwd + "/tools.go"`).
 
 All other arguments are passed verbatim to `stdenv.mkDerivation`.


### PR DESCRIPTION
Looks to tackle: https://github.com/nix-community/gomod2nix/issues/95

Also parameterises the modules file in `mkGoEnv` which makes it similar to `goBuildApplication`.