### PR TITLE
Use `nix eval` instead of `nix-instantiate` for `gomod2nix import`

### DIFF
--- a/internal/generate/generate.go
+++ b/internal/generate/generate.go
@@ -107,8 +107,9 @@ func ImportPkgs(directory string, numWorkers int) error {
 			pathName := filepath.Base(dl.Path) + "_" + dl.Version
 
 			cmd := exec.Command(
-				"nix-instantiate",
-				"--eval",
+				"nix",
+				"eval",
+				"--impure",
 				"--expr",
 				fmt.Sprintf(`
 builtins.filterSource (name: type: baseNameOf name != ".DS_Store") (


### PR DESCRIPTION
Fixes https://github.com/nix-community/gomod2nix/issues/72