### PR TITLE
Expose mkVendorEnv

### DIFF
--- a/overlay.nix
+++ b/overlay.nix
@@ -5,6 +5,6 @@ let
   callPackage = final.darwin.apple_sdk_11_0.callPackage or final.callPackage;
 in
 {
-  inherit (callPackage ./builder { }) buildGoApplication mkGoEnv;
+  inherit (callPackage ./builder { }) buildGoApplication mkGoEnv mkVendorEnv;
   gomod2nix = callPackage ./default.nix { };
 }


### PR DESCRIPTION
This is useful in case one wishes to use `gomod2nix` flake only for generating the `vendor` directory, and use Nixpkgs' `buildGoModule`.