### PR TITLE
Expose flake interface that does not rely on overlays 

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -63,7 +63,7 @@ pkgs.buildGoApplication {
 
 The quickest way to get started if using Nix Flakes is to use the Flake template:
 ``` bash
-$ nix flake init -t github:tweag/gomod2nix#app
+$ nix flake init -t github:nix-community/gomod2nix#app
 ```
 
 ## Basic usage

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,23 @@
 {
   "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1694529238,
+        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1658285632,
@@ -18,22 +36,22 @@
     },
     "root": {
       "inputs": {
-        "nixpkgs": "nixpkgs",
-        "utils": "utils"
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
       }
     },
-    "utils": {
+    "systems": {
       "locked": {
-        "lastModified": 1653893745,
-        "narHash": "sha256-0jntwV3Z8//YwuOjzhV2sgJJPt+HY6KhU7VZUL0fKZQ=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "1ed9fb1935d260de5fe1c2f7ee0ebaae17ed2fa1",
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
         "type": "github"
       },
       "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
+        "owner": "nix-systems",
+        "repo": "default",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -2,10 +2,9 @@
   description = "Convert go.mod/go.sum to Nix packages";
 
   inputs.nixpkgs.url = "github:NixOS/nixpkgs/master";
+  inputs.flake-utils.url = "github:numtide/flake-utils";
 
-  inputs.utils.url = "github:numtide/flake-utils";
-
-  outputs = { self, nixpkgs, utils }:
+  outputs = { self, nixpkgs, flake-utils }:
     {
       overlays.default = import ./overlay.nix;
 
@@ -18,7 +17,7 @@
       defaultTemplate = self.templates.app;
 
     } //
-    (utils.lib.eachDefaultSystem
+    (flake-utils.lib.eachDefaultSystem
       (system:
         let
           pkgs = nixpkgs.legacyPackages.${system};

--- a/flake.nix
+++ b/flake.nix
@@ -23,8 +23,8 @@
         let
           pkgs = nixpkgs.legacyPackages.${system};
 
-          # The newer Darwin SDK does not exist in current (nixos-22.05) stable
-          # branches, so just fallback to the default callPackage.
+          # The current default sdk for macOS fails to compile go projects, so we use a newer one for now.
+          # This has no effect on other platforms.
           callPackage = pkgs.darwin.apple_sdk_11_0.callPackage or pkgs.callPackage;
 
           inherit (callPackage ./builder {

--- a/overlay.nix
+++ b/overlay.nix
@@ -1,7 +1,7 @@
 final: prev:
 let
-  # The newer Darwin SDK does not exist in current (nixos-22.05) stable
-  # branches, so just fallback to the default callPackage.
+  # The current default sdk for macOS fails to compile go projects, so we use a newer one for now.
+  # This has no effect on other platforms.
   callPackage = final.darwin.apple_sdk_11_0.callPackage or final.callPackage;
 in
 {

--- a/shell.nix
+++ b/shell.nix
@@ -8,6 +8,8 @@
       ];
     }
   )
+, gomod2nix ? pkgs.gomod2nix
+, mkGoEnv ? pkgs.mkGoEnv
 }:
 
 pkgs.mkShell {
@@ -15,7 +17,7 @@ pkgs.mkShell {
   nativeBuildInputs = [
     pkgs.nixpkgs-fmt
     pkgs.golangci-lint
-    pkgs.gomod2nix
-    (pkgs.mkGoEnv { pwd = ./.; })
+    gomod2nix
+    (mkGoEnv { pwd = ./.; })
   ];
 }

--- a/templates/app/default.nix
+++ b/templates/app/default.nix
@@ -9,9 +9,10 @@
       ];
     }
   )
+, buildGoApplication ? pkgs.buildGoApplication
 }:
 
-pkgs.buildGoApplication {
+buildGoApplication {
   pname = "myapp";
   version = "0.1";
   pwd = ./.;

--- a/templates/app/flake.nix
+++ b/templates/app/flake.nix
@@ -10,12 +10,16 @@
       (system:
         let
           pkgs = nixpkgs.legacyPackages.${system};
+
+          # The current default sdk for macOS fails to compile go projects, so we use a newer one for now.
+          # This has no effect on other platforms.
+          callPackage = pkgs.darwin.apple_sdk_11_0.callPackage or pkgs.callPackage;
         in
         {
-          packages.default = pkgs.callPackage ./. {
-             inherit (gomod2nix.legacyPackages.${system}) buildGoApplication;
+          packages.default = callPackage ./. {
+            inherit (gomod2nix.legacyPackages.${system}) buildGoApplication;
           };
-          devShells.default = pkgs.callPackage ./shell.nix {
+          devShells.default = callPackage ./shell.nix {
             inherit (gomod2nix.legacyPackages.${system}) buildGoApplication mkGoEnv gomod2nix;
           };
         })

--- a/templates/app/flake.nix
+++ b/templates/app/flake.nix
@@ -4,6 +4,8 @@
   inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
   inputs.flake-utils.url = "github:numtide/flake-utils";
   inputs.gomod2nix.url = "github:nix-community/gomod2nix";
+  inputs.gomod2nix.inputs.nixpkgs.follows = "nixpkgs";
+  inputs.gomod2nix.inputs.flake-utils.follows = "flake-utils";
 
   outputs = { self, nixpkgs, flake-utils, gomod2nix }:
     (flake-utils.lib.eachDefaultSystem

--- a/templates/app/flake.nix
+++ b/templates/app/flake.nix
@@ -9,15 +9,15 @@
     (flake-utils.lib.eachDefaultSystem
       (system:
         let
-          pkgs = import nixpkgs {
-            inherit system;
-            overlays = [ gomod2nix.overlays.default ];
-          };
-
+          pkgs = nixpkgs.legacyPackages.${system};
         in
         {
-          packages.default = pkgs.callPackage ./. { };
-          devShells.default = import ./shell.nix { inherit pkgs; };
+          packages.default = pkgs.callPackage ./. {
+             inherit (gomod2nix.legacyPackages.${system}) buildGoApplication;
+          };
+          devShells.default = pkgs.callPackage ./shell.nix {
+            inherit (gomod2nix.legacyPackages.${system}) buildGoApplication mkGoEnv gomod2nix;
+          };
         })
     );
 }

--- a/templates/app/shell.nix
+++ b/templates/app/shell.nix
@@ -9,14 +9,16 @@
       ];
     }
   )
+, mkGoEnv ? pkgs.mkGoEnv
+, gomod2nix ? pkgs.gomod2nix
 }:
 
 let
-  goEnv = pkgs.mkGoEnv { pwd = ./.; };
+  goEnv = mkGoEnv { pwd = ./.; };
 in
 pkgs.mkShell {
   packages = [
     goEnv
-    pkgs.gomod2nix
+    gomod2nix
   ];
 }


### PR DESCRIPTION
As creator of small tools, my flakes might often end up in other peoples
projects. Overlays are a performance problem in those use cases because
it would kept re-instantiating nixpkgs instances. Of course I could also
expose my stuff as overlays as well.

In that case I would need to merge downstream dependencies like
go2modnix as well, which would pollute their nixpkgs instance with
unrelated stuff and also make it harder for my users to tell what random
attributes came from which place.