### PR TITLE
Call `templates/app/shell.nix` without `buildGoApplication`

### DIFF
--- a/templates/app/flake.nix
+++ b/templates/app/flake.nix
@@ -22,7 +22,7 @@
             inherit (gomod2nix.legacyPackages.${system}) buildGoApplication;
           };
           devShells.default = callPackage ./shell.nix {
-            inherit (gomod2nix.legacyPackages.${system}) buildGoApplication mkGoEnv gomod2nix;
+            inherit (gomod2nix.legacyPackages.${system}) mkGoEnv gomod2nix;
           };
         })
     );


### PR DESCRIPTION
After running `nix flake init -t github:nix-community/gomod2nix#app`, I get:

```console
$ nix develop               
error:
       … while evaluating a branch condition

         at /nix/store/cz973qsjldbw4x7fx0rwcvhr9k645vz2-source/lib/customisation.nix:86:7:

           85|     in
           86|       if builtins.isAttrs result then
             |       ^
           87|         result // {

       … while calling the 'isAttrs' builtin

         at /nix/store/cz973qsjldbw4x7fx0rwcvhr9k645vz2-source/lib/customisation.nix:86:10:

           85|     in
           86|       if builtins.isAttrs result then
             |          ^
           87|         result // {

       (stack trace truncated; use '--show-trace' to show the full trace)

       error: function 'anonymous lambda' called with unexpected argument 'buildGoApplication'

       at /nix/store/r3n8i1plbj7jfns97b73ckm5rh40x7s5-source/shell.nix:1:1:

            1| { pkgs ? (
             | ^
            2|     let
```

Indeed, `templates/app/shell.nix` has no `buildGoApplication` parameter:

https://github.com/nix-community/gomod2nix/blob/f95720e89af6165c8c0aa77f180461fe786f3c21/templates/app/shell.nix#L1-L14