### PR TITLE
Fix: flake template start

### DIFF
--- a/templates/app/flake.nix
+++ b/templates/app/flake.nix
@@ -22,7 +22,7 @@
             inherit (gomod2nix.legacyPackages.${system}) buildGoApplication;
           };
           devShells.default = callPackage ./shell.nix {
-            inherit (gomod2nix.legacyPackages.${system}) buildGoApplication mkGoEnv gomod2nix;
+            inherit (gomod2nix.legacyPackages.${system}) mkGoEnv gomod2nix;
           };
         })
     );


### PR DESCRIPTION
Hi, thank you for this repository.

This is the only way I found to make the project run using flakes.

When running: 
```
nix flake init -t "github:nix-community/gomod2nix#app"
echo "use flake" > .envrc
direnv allow
```

My shell returns: 
```
error:
       … from call site

         at /nix/store/xl2g314lf8967lwdz3ynj8p5g6p2b6rh-source/flake.nix:24:31:

           23|           };
           24|           devShells.default = callPackage ./shell.nix {
             |                               ^
           25|             inherit (gomod2nix.legacyPackages.${system}) buildGoApplication mkGoEnv gomod2nix;

       … while calling 'callPackageWith'

         at /nix/store/09yvj6yyxspzfivv91bcxwrjxawpk1g2-source/lib/customisation.nix:122:35:

          121|   */
          122|   callPackageWith = autoArgs: fn: args:
             |                                   ^
          123|     let

       … from call site

         at /nix/store/09yvj6yyxspzfivv91bcxwrjxawpk1g2-source/lib/customisation.nix:173:34:

          172|
          173|     in if missingArgs == [] then makeOverridable f allArgs else abort error;
             |                                  ^
          174|

       … while calling 'makeOverridable'

         at /nix/store/09yvj6yyxspzfivv91bcxwrjxawpk1g2-source/lib/customisation.nix:72:24:

           71|   */
           72|   makeOverridable = f: origArgs:
             |                        ^
           73|     let

       error: function 'anonymous lambda' called with unexpected argument 'buildGoApplication'

       at /nix/store/xl2g314lf8967lwdz3ynj8p5g6p2b6rh-source/shell.nix:1:1:

            1| { pkgs ? (
             | ^
            2|     let


```

So this is a *stupid* *quick* and *dirty* fix. 
