### PR TITLE
Remove usage of filterSource in gomod2nix import

### DIFF
--- a/internal/generate/generate.go
+++ b/internal/generate/generate.go
@@ -111,12 +111,11 @@ func ImportPkgs(directory string, numWorkers int) error {
 				"--eval",
 				"--expr",
 				fmt.Sprintf(`
-builtins.filterSource (name: type: baseNameOf name != ".DS_Store") (
-  builtins.path {
-    path = "%s";
-    name = "%s";
-  }
-)
+builtins.path {
+  path = "%s";
+  name = "%s";
+  filter = (name: type: baseNameOf name != ".DS_Store");
+}
 `, dl.Dir, pathName),
 			)
 			cmd.Stderr = os.Stderr


### PR DESCRIPTION
When running gomod2nix import, the calls to nix-instantiate fail with the following error:

```
error:
       … while calling the 'filterSource' builtin
         at «string»:2:1:
            1|
            2| builtins.filterSource (name: type: baseNameOf name != ".DS_Store") (
             | ^
            3|   builtins.path {

       … while adding path '/nix/store/aiskw3qix131gdmdjnsywqcqpn7jjr6a-aws-sdk-go_v1.50.27'

       error: path '/nix/store/aiskw3qix131gdmdjnsywqcqpn7jjr6a-aws-sdk-go_v1.50.27' is not valid
/nix/var/nix/profiles/default/bin/nix-instantiate --eval --expr
builtins.filterSource (name: type: baseNameOf name != ".DS_Store") (
  builtins.path {
    path = "/home/ianwork/go/pkg/mod/github.com/aws/aws-sdk-go@v1.50.27";
    name = "aws-sdk-go_v1.50.27";
  }
)
```

When looking at the docs, it appears the 'builtins.path' can take a 'filter', which also seems to be the preferred way: there are warnings about using 'filterSource' in the docs:

https://nixos.org/manual/nix/stable/language/builtins.html#builtins-filterSource

After making this change, I no longer get the previous error on my machine"