### PR TITLE
fix: overlapped local replacement

### DIFF
--- a/builder/default.nix
+++ b/builder/default.nix
@@ -84,7 +84,8 @@ let
               (name: value: (
                 ''
                   mkdir -p $(dirname vendor/${name})
-                  ln -s ${pwd + "/${value.path}"} vendor/${name}
+                  # sometimes the symlink already exists, so we ignore the error
+                  ln -s ${pwd + "/${value.path}"} vendor/${name} || true
                 ''
               ))
               localReplaceAttrs);


### PR DESCRIPTION
One golang standalone module can exists inside another module, when we replace such module to local directory, we'll try to create symbolic link inside the source directory and `ln` complains permission denied.

For example, both `cosmossdk.io/x/accounts` and `cosmossdk.io/x/accounts/defaults/lockup` are standalone modules, if we do `replace cosmossdk.io/x/accounts => ./x/accounts`, we'll try to create two symbolic links like this:

```
$ ln -s ./x/accounts vendor/cosmossdk.io/x/accounts
$ ln -s ./x/accounts/defaults/lockup vendor/cosmossdk.io/x/accounts/defaults/lockup
```

And the second one is inside source directory and fails.

The temporary solution here is to simply ignore the symbolic link error, not ideal, but fix the issue at hand, and should have not side effect on existing projects.