### PR TITLE
Enter vendor directories recursively when symlinking fails

### DIFF
--- a/builder/symlink/symlink.go
+++ b/builder/symlink/symlink.go
@@ -92,18 +92,7 @@ func populateVendorPath(vendorPath string, src string) {
 		dst := filepath.Join(vendorPath, f.Name())
 		if err := os.Symlink(innerSrc, dst); err != nil {
 			// assume it's an existing directory, try to link the directory content instead.
-			// TODO should we do this recursively?
-			files, err := os.ReadDir(innerSrc)
-			if err != nil {
-				panic(err)
-			}
-			for _, f := range files {
-				srcFile := filepath.Join(innerSrc, f.Name())
-				dstFile := filepath.Join(dst, f.Name())
-				if err := os.Symlink(srcFile, dstFile); err != nil {
-					fmt.Println("ignoring symlink error", srcFile, dstFile)
-				}
-			}
+			populateVendorPath(dst, innerSrc)
 		}
 	}
 }


### PR DESCRIPTION
There could be several levels of already-existing directories.

An example of this is version 0.6.0 of guac (https://github.com/guacsec/guac), where there is `github.com/aws/aws-sdk-go-v2/aws` and several `github.com/aws/aws-sdk-go-v2/aws/protocol/*`, but no `github.com/aws/aws-sdk-go-v2/aws/protocol`.

There is no risk of infinite recursion here because it goes down the directory hierarchy one level each recursive call, and will terminate when no directory is found here anymore. The exception to this is when both the existing tree and the new vendored dependency have the same symlink loop, but that seems unlikely.

It would be good to have a unit test for this behaviour, but it's been a while since I did go seriously, so I'd like to leave it at this.