### PR TITLE
fix(builder): allow additional attributes in mkGoEnv derivation

### DIFF
--- a/builder/default.nix
+++ b/builder/default.nix
@@ -163,6 +163,7 @@ let
     { pwd
     , toolsGo ? pwd + "/tools.go"
     , modules ? pwd + "/gomod2nix.toml"
+    , ...
     }@attrs:
     let
       goMod = parseGoMod (readFile "${toString pwd}/go.mod");


### PR DESCRIPTION
Extended the mkGoEnv derivation to accept additional attributes by introducing a variadic argument. This change provides the intended behavior of the mkGoEnv derivation, which is to allow the user to pass additional attributes to mkDerivation.