### PR TITLE
Fix: add back darwin support

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -19,8 +19,10 @@
     }
     // (flake-utils.lib.eachSystem
       [
-        "x86_64-linux"
         "aarch64-linux"
+        "aarch64-darwin"
+        "x86_64-darwin"
+        "x86_64-linux"
         "riscv64-linux"
       ]
       (


### PR DESCRIPTION
Fixes a regression where darwin support was deleted. We now take the full default value of `defaultSystems` from flake-utils and add riscv to it.

Addresses #164.