### PR TITLE
docs(nix-reference): update docs to include additional parameters

### DIFF
--- a/docs/nix-reference.md
+++ b/docs/nix-reference.md
@@ -3,20 +3,27 @@
 ## Public functions
 
 ### buildGoApplication
+
 Arguments:
-- **modules** Path to `gomod2nix.toml` (_default: `pwd + "/gomod2nix.toml"`).
-- **src** Path to sources (_default: `pwd`).
-- **pwd** Path to working directory (_default: `null`).
+
+- **modules** Path to `gomod2nix.toml` (\_default: `pwd + "/gomod2nix.toml"`).
+- **src** Path to sources (\_default: `pwd`).
+- **pwd** Path to working directory (\_default: `null`).
 - **go** The Go compiler to use (can be omitted).
 - **subPackages** Only build these specific sub packages.
-- **allowGoReference** Allow references to the Go compiler in the output closure (_default: `false`).
+- **allowGoReference** Allow references to the Go compiler in the output closure (\_default: `false`).
+- **tags** A list of tags to pass the Go compiler during the build (\_default: `[ ]`).
+- **ldflags** A list of `ldflags` to pass the Go compiler during the build (\_default: `[ ]`).
+- **nativeBuildInputs** A list of packages to include in the build derivation (\_default: `[ ]`).
 
 All other arguments are passed verbatim to `stdenv.mkDerivation`.
 
 ### mkGoEnv
+
 Arguments:
+
 - **pwd** Path to working directory.
-- **modules** Path to `gomod2nix.toml` (_default: `pwd + "/gomod2nix.toml"`).
-- **toolsGo** Path to `tools.go` (_default: `pwd + "/tools.go"`).
+- **modules** Path to `gomod2nix.toml` (\_default: `pwd + "/gomod2nix.toml"`).
+- **toolsGo** Path to `tools.go` (\_default: `pwd + "/tools.go"`).
 
 All other arguments are passed verbatim to `stdenv.mkDerivation`.


### PR DESCRIPTION
Similar to #109 , I wanted to pass tags to my build, but it was not obvious from the documentation about how to do so.

It seems like there were a few parameters in the build that are available to the user (in this case, `tags`) that are useful but are not documented outside of the nix code itself.

This small PR just adds them to the documents to make it easier to find.

resolves #109 