### PR TITLE
Show failed command and its output.

### DIFF
--- a/internal/generate/generate.go
+++ b/internal/generate/generate.go
@@ -71,7 +71,11 @@ func common(directory string) ([]*goModDownload, map[string]string, error) {
 		cmd.Dir = directory
 		stdout, err := cmd.Output()
 		if err != nil {
-			return nil, nil, err
+			if exiterr, ok := err.(*exec.ExitError); ok {
+				return nil, nil, fmt.Errorf("Failed to run 'go mod download --json: %s\n%s", exiterr, exiterr.Stderr)
+			} else {
+				return nil, nil, fmt.Errorf("Failed to run 'go mod download --json': %s", err)
+			}
 		}
 
 		dec := json.NewDecoder(bytes.NewReader(stdout))


### PR DESCRIPTION
Not the cleanest way to show the command being used, but at least this way we capture any output it produces and show it to the user to give them a clue about what they can do.

Addresses Issue #181 