### PR TITLE
feat(builder): adds git as nativeBuildInputs to fetchGoModule

### DIFF
--- a/builder/default.nix
+++ b/builder/default.nix
@@ -4,6 +4,7 @@
 , buildEnv
 , lib
 , fetchgit
+, git
 , jq
 , cacert
 , pkgsBuildBuild
@@ -58,6 +59,7 @@ let
       inherit goPackagePath version;
       nativeBuildInputs = [
         go
+        git
         jq
         cacert
       ];


### PR DESCRIPTION
This PR adds `git` package as a dependency to `fetchGoModule`

Due to the Go logic of dependency handling, first it tries to search for deps in Go proxy, and if it could not find desired dependency there, Go goes to VCS. However, dut to the absence of installed git during fetch, build fails with: `exec: "git": executable file not found in $PATH`

This PR should help to fix this error