### PR TITLE
fix: bypass go_1_22

### DIFF
--- a/builder/default.nix
+++ b/builder/default.nix
@@ -133,7 +133,7 @@ let
       goVersion = goMod.go;
       goAttrs = lib.reverseList (builtins.filter
         (
-          attr: lib.hasPrefix "go_" attr && lib.versionAtLeast buildPackages.${attr}.version goVersion
+          attr: lib.hasPrefix "go_" attr && attr != "go_1_22" && lib.versionAtLeast buildPackages.${attr}.version goVersion
         )
         (lib.attrNames buildPackages));
       goAttr = elemAt goAttrs 0;


### PR DESCRIPTION
Since https://github.com/NixOS/nixpkgs/pull/394017 , `go_1_22` throws an exception.

This is an ugly yet minimal patch to avoid accessing it.