### PR TITLE
fix: bug around go version 1.22 throwing an exception

### DIFF
--- a/builder/default.nix
+++ b/builder/default.nix
@@ -133,7 +133,10 @@ let
       goVersion = goMod.go;
       goAttrs = lib.reverseList (builtins.filter
         (
-          attr: lib.hasPrefix "go_" attr && lib.versionAtLeast buildPackages.${attr}.version goVersion
+          attr:
+          lib.hasPrefix "go_" attr &&
+          (let try = builtins.tryEval buildPackages.${attr}; in try.success && try.value ? version) &&
+          lib.versionAtLeast buildPackages.${attr}.version goVersion
         )
         (lib.attrNames buildPackages));
       goAttr = elemAt goAttrs 0;


### PR DESCRIPTION
Any evaluation of the [go_1_22 package will throw](https://github.com/NixOS/nixpkgs/blob/cce8b29315dce266bbab9f1dcd1c76d54583c307/pkgs/top-level/aliases.nix#L713) an exception. This was causing the `selectGo` function to fail with a cryptic message saying that go 1.22 was not supported, even when there was no reference at all of it anywhere.

These changes will ensure that when we loop through the available go packages, we test them against any `throw` alias - which are used for deprecation.

This should fix https://github.com/nix-community/gomod2nix/pull/197