### PR TITLE
add: custom flake checks for testing and linting

### DIFF
--- a/templates/app/flake.nix
+++ b/templates/app/flake.nix
@@ -7,23 +7,67 @@
   inputs.gomod2nix.inputs.nixpkgs.follows = "nixpkgs";
   inputs.gomod2nix.inputs.flake-utils.follows = "flake-utils";
 
-  outputs = { self, nixpkgs, flake-utils, gomod2nix }:
-    (flake-utils.lib.eachDefaultSystem
-      (system:
-        let
-          pkgs = nixpkgs.legacyPackages.${system};
+  outputs =
+    { self
+    , nixpkgs
+    , flake-utils
+    , gomod2nix
+    ,
+    }:
+    (flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
 
-          # The current default sdk for macOS fails to compile go projects, so we use a newer one for now.
-          # This has no effect on other platforms.
-          callPackage = pkgs.darwin.apple_sdk_11_0.callPackage or pkgs.callPackage;
-        in
-        {
-          packages.default = callPackage ./. {
-            inherit (gomod2nix.legacyPackages.${system}) buildGoApplication;
-          };
-          devShells.default = callPackage ./shell.nix {
-            inherit (gomod2nix.legacyPackages.${system}) mkGoEnv gomod2nix;
-          };
-        })
-    );
+        # The current default sdk for macOS fails to compile go projects, so we use a newer one for now.
+        # This has no effect on other platforms.
+        callPackage = pkgs.darwin.apple_sdk_11_0.callPackage or pkgs.callPackage;
+        # Simple test check added to nix flake check
+        go-test = pkgs.stdenvNoCC.mkDerivation {
+          name = "go-test";
+          dontBuild = true;
+          src = ./.;
+          doCheck = true;
+          nativeBuildInputs = with pkgs; [
+            go
+            writableTmpDirAsHomeHook
+          ];
+          checkPhase = ''
+            go test -v ./...
+          '';
+          installPhase = ''
+            mkdir "$out"
+          '';
+        };
+        # Simple lint check added to nix flake check
+        go-lint = pkgs.stdenvNoCC.mkDerivation {
+          name = "go-lint";
+          dontBuild = true;
+          src = ./.;
+          doCheck = true;
+          nativeBuildInputs = with pkgs; [
+            golangci-lint
+            go
+            writableTmpDirAsHomeHook
+          ];
+          checkPhase = ''
+            golangci-lint run
+          '';
+          installPhase = ''
+            mkdir "$out"
+          '';
+        };
+      in
+      {
+        checks = {
+          inherit go-test go-lint;
+        };
+        packages.default = callPackage ./. {
+          inherit (gomod2nix.legacyPackages.${system}) buildGoApplication;
+        };
+        devShells.default = callPackage ./shell.nix {
+          inherit (gomod2nix.legacyPackages.${system}) mkGoEnv gomod2nix;
+        };
+      }
+    ));
 }

--- a/templates/app/main_test.go
+++ b/templates/app/main_test.go
@@ -1,0 +1,12 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestMain(t *testing.T) {
+	got := "Hello flake"
+	if got != "Hello flake" {
+		t.Errorf("main: %s; want Hello flake", got)
+	}
+}


### PR DESCRIPTION
This PR aims to introduce a few custom checks in the flake that might be a slightly QoL additions.
* add -> basic check for linting using golangci-lint
* add -> basic check for go test -v ./....

by running `nix flake check` it would use those as some very basic local CI.

I could also add in this PR or another some custom scripts that would do the same as the flake checks but would be run and displayed through the devshell provided by gomod2nix