### PR TITLE
fix build on nixpkgs-unstable

### DIFF
--- a/builder/default.nix
+++ b/builder/default.nix
@@ -282,7 +282,7 @@ let
           export GOPATH="$TMPDIR/go"
           export GOSUMDB=off
           export GOPROXY=off
-          cd "$modRoot"
+          cd "''${modRoot:-.}"
 
           ${optionalString (modulesStruct != { }) ''
             if [ -n "${vendorEnv}" ]; then


### PR DESCRIPTION
Seemingly modRoot isn’t being set anymore, so set it to the default of `.` if it’s unset.

Fixes #206