### PR TITLE
fix builds within darwin sandbox

### DIFF
--- a/builder/default.nix
+++ b/builder/default.nix
@@ -34,7 +34,8 @@ let
           nativeBuildInputs = [ pkgsBuildBuild.go ];
         } ''
         export HOME=$(mktemp -d)
-        go build -o $out ${src}
+        go build -o "$HOME/bin" ${src}
+        mv "$HOME/bin" "$out"
       '';
     in
     {


### PR DESCRIPTION
For some reason, when Go outputs binaries directly to `$out` with the sandbox enabled on macOS, it creates the file with a permission value of 755, which makes Nix bail out:

> error: suspicious ownership or permission on '/nix/store/5ddbav00in71k7byvvbhhqxqhw83phqc-meow' for output 'out'; rejecting this build output

The simplest fix is to output the binary to a temporary directory, and then move it into place.